### PR TITLE
기본 인증과 채팅 기능 구현

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,7 @@ async fn websocket(stream: WebSocket, state: Arc<AppState>, sid: String) {
                         }
                     };
 
-                    req.handle(&sid, ub_tx.clone(), &state).await;
+                    req.handle(sid.clone(), ub_tx.clone(), &state).await;
                 }
                 _ => {
                     tracing::error!("{:?} Wrong Request {}", packet.op_code, payload);

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -6,12 +6,15 @@
 
 use std::sync::Arc;
 
+use axum::{extract::ws::Message, Error};
 use chrono::prelude::*;
+use fred::prelude::PubsubInterface;
 use num_enum::TryFromPrimitive;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
+use tokio::sync::mpsc::UnboundedSender;
 
-use crate::AppState;
+use crate::{session::User, AppState, REDIS_CHANNEL_NAME};
 
 /// 프로토콜
 #[derive(Debug, TryFromPrimitive, Serialize_repr, Deserialize_repr)]
@@ -22,6 +25,10 @@ pub enum PacketKind {
     AuthRequest = 10,
     AuthSuccess = 11,
     AuthFail = 12,
+    SendTextRequest = 101,
+    SendTextSuccess = 102,
+    /// 인증 정보 누락으로 실패 처리
+    SendTextFail = 103,
 }
 
 // @TODO 응답에 op_code 추가
@@ -29,9 +36,9 @@ pub enum PacketKind {
 //     serde_json::to_string(&T).unwrap_or_default(),
 // }
 
-/// 통신 패킷 체크 응답
+/// 요청 패킷 구조
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Packet {
+pub struct Request {
     /// op code
     #[serde(rename = "o")]
     pub op_code: PacketKind,
@@ -40,7 +47,15 @@ pub struct Packet {
     pub payload: serde_json::Value,
 }
 
-/// 통신 상태 체크 요청
+/// 응답 패킷 구조
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Response {
+    /// 전체 전파 해야할 내용인지 송신자에게만 전달해야할 내용인지 여부
+    pub is_broad_cast: bool,
+    /// 페이로드
+    pub payload: String,
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Ping {
     /// epoch from client
@@ -61,7 +76,6 @@ impl Ping {
     }
 }
 
-/// 인증 요청
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AuthRequest {
     #[serde(rename = "n")]
@@ -74,19 +88,36 @@ impl AuthRequest {
     /// 요청 패킷 처리
     pub async fn handle(&self, sid: &str, state: &Arc<AppState>) -> String {
         // 함수가 끝나면 자동 lock 해제
-        let mut user_set = state.user_set.lock().unwrap();
+        let mut users = state.users.lock().unwrap();
+        let mut sessions = state.sessions.lock().unwrap();
 
         // 일단 중복 아이디일 경우 인증 실패 처리
-        let json = if !user_set.contains(&self.user_id) {
-            user_set.insert(self.user_id.to_owned());
-            serde_json::json!({
-                "o": PacketKind::AuthSuccess,
-                "n": self.user_name,
-                "i": self.user_id,
-                "s": sid,
-            })
+        let json = if !users.contains_key(&self.user_id) {
+            if let Some(session) = sessions.get_mut(sid) {
+                // 유저 아이이디에 해당 세션 아이디를 넣고 유저정보에도 인증 정보를 담는다
+                users.insert(self.user_id.clone(), sid.into());
+                let user_info = User {
+                    id: self.user_id.clone(),
+                    name: self.user_name.clone(),
+                };
+                session.auth(user_info);
+                serde_json::json!({
+                    "o": PacketKind::AuthSuccess,
+                    "n": self.user_name,
+                    "i": self.user_id,
+                    "s": sid,
+                })
+            } else {
+                tracing::error!("테스트용 인증 실패: 세션 정보에 해당 세션이 없음 {}", sid);
+                serde_json::json!({
+                    "o": PacketKind::AuthFail,
+                    "n": self.user_name,
+                    "i": self.user_id,
+                    "s": sid,
+                })
+            }
         } else {
-            tracing::error!("테스트용 인증 실패 {}", sid);
+            tracing::error!("테스트용 인증 실패: 이미 인증된 세션임 {}", sid);
             serde_json::json!({
                 "o": PacketKind::AuthFail,
                 "n": self.user_name,
@@ -95,5 +126,68 @@ impl AuthRequest {
             })
         };
         format!("{}", json)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SendTextRequest {
+    #[serde(rename = "c")]
+    pub content: String,
+}
+
+impl SendTextRequest {
+    /// 요청 패킷 처리
+    pub async fn handle(
+        &self,
+        sid: &str,
+        tx: UnboundedSender<Result<Message, Error>>,
+        state: &Arc<AppState>,
+    ) {
+        // 함수가 끝나면 자동 lock 해제
+        let sessions = state.sessions.lock().unwrap();
+
+        match sessions.get(sid) {
+            Some(v) => {
+                match v.user() {
+                    Some(u) => {
+                        // 인증 된 세션이라 채팅 전파
+                        let json = serde_json::json!({
+                            "o": PacketKind::SendTextSuccess,
+                            "c": self.content,
+                            "n": u.name,
+                            "i": u.id,
+                        });
+                        let msg = format!("{}", json);
+
+                        // redis publish로 브로드 캐스팅
+                        tracing::debug!("SendTextRequest 성공 {} {}", sid, msg);
+                        let redis_client = state.redis_client.clone();
+                        let received_clients: i64 =
+                            redis_client.publish(REDIS_CHANNEL_NAME, msg).await.unwrap();
+                    }
+                    None => {
+                        // 인증 안되서 전파 실패 처리
+                        tracing::error!("인증 안된 세션이래 채팅 전파 실패 {}", sid);
+                        let json = serde_json::json!({
+                            "o": PacketKind::SendTextFail,
+                            "s": sid,
+                        });
+                        let msg = format!("{}", json);
+                        // 송신자에게만 전파
+                        let _ = tx.send(Ok(Message::Text(msg)));
+                    }
+                }
+            }
+            None => {
+                tracing::error!("SendTextRequest 실패: 세션 정보에 해당 세션이 없음 {}", sid);
+                let json = serde_json::json!({
+                    "o": PacketKind::SendTextFail,
+                    "s": sid,
+                });
+                let msg = format!("{}", json);
+                // 송신자에게만 전파
+                let _ = tx.send(Ok(Message::Text(msg)));
+            }
+        };
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -6,13 +6,12 @@
 
 use std::sync::Arc;
 
-use axum::{extract::ws::Message, Error};
+use axum::extract::ws::Message;
 use chrono::prelude::*;
 use fred::prelude::PubsubInterface;
 use num_enum::TryFromPrimitive;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{session::User, AppState, WebsocketTx, REDIS_CHANNEL_NAME};
 
@@ -65,7 +64,7 @@ pub struct Ping {
 
 impl Ping {
     /// 요청 패킷 처리
-    pub async fn handle(&self, sid: String, tx: WebsocketTx, now: NaiveDateTime) {
+    pub async fn handle(&self, _sid: String, tx: WebsocketTx, now: NaiveDateTime) {
         let json = serde_json::json!({
             "o": PacketKind::Pong,
             "t1": &self.client_epoch,

--- a/src/session.rs
+++ b/src/session.rs
@@ -45,5 +45,5 @@ pub struct User {
 
 pub fn add_session(state: &AppState, sid: &str, tx: WebsocketTx) {
     let mut sessions = state.sessions.lock().unwrap();
-    sessions.insert(sid.to_owned(), Session::new(&sid, tx));
+    sessions.insert(sid.to_owned(), Session::new(sid, tx));
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -4,6 +4,8 @@ use axum::{extract::ws::Message, Error};
 use bson::oid::ObjectId;
 use tokio::sync::mpsc::UnboundedSender;
 
+use crate::{AppState, WebsocketTx};
+
 pub fn generate_id() -> String {
     format!("ws{}", ObjectId::new())
 }
@@ -39,4 +41,9 @@ impl Session {
 pub struct User {
     pub id: String,
     pub name: String,
+}
+
+pub fn add_session(state: &AppState, sid: &str, tx: WebsocketTx) {
+    let mut sessions = state.sessions.lock().unwrap();
+    sessions.insert(sid.to_owned(), Session::new(&sid, tx));
 }

--- a/static/chat.html
+++ b/static/chat.html
@@ -44,6 +44,8 @@
     <p>{"o":1,"t":1660366398662}</p>
     <p>AuthRequest</p>
     <p>{"o":10,"n":"user_name","i":"user_id"}</p>
+    <p>SendTextRequest</p>
+    <p>{"o":101,"c":"안녕"}</p>
     <script type="text/javascript">
         const server = document.getElementById('server');
         const chat = document.getElementById('chat');


### PR DESCRIPTION
웹소켓 세션을 관리하는 repo 개념을 만들어 인증된 세션인지 인증된 유저의 세션은 무엇인지 에대한 정보를 관리하게 하였음

프로토콜도 enum화 해서 구조를 확립했고 레디스를 통해 pubsub 하고 수신 프로토콜을 파싱해서 전체 전파냐 해당 송신자에게만 전파냐 분기해서 전송할수있게 하였음

tokio task를 실행해야지만 await 가능한 코드를 웹소켓 수신 핸들러에서 호출 가능하다는거

여러 클라이언트가 웹소켓 연결해도 레디스 pubsub channel 을 subscribe 하는 클라이언트는 1개인거 확인함 이게 매우 중요한게 pubsub 브로드 캐스팅 성능에 제일 큰 영향을 미치거든

Resolves #12 #8 #4 