### PR TITLE
채팅방 개념 구현

### DIFF
--- a/examples/ws_client.rs
+++ b/examples/ws_client.rs
@@ -84,6 +84,11 @@ pub async fn run_test(status: Arc<Mutex<Status>>) {
         rand::random::<i64>()
     );
     write.send(Message::from(msg)).await.unwrap();
+    // 채팅방 조인
+    write
+        .send(Message::from(r#"{"o":181,"r":"room_id"}"#))
+        .await
+        .unwrap();
 
     // 0.3초 마다 랜덤 숫자 넣은 채팅 전송
     let cloned_status = status.clone();
@@ -92,7 +97,7 @@ pub async fn run_test(status: Arc<Mutex<Status>>) {
         loop {
             interval.tick().await;
             let msg = format!(
-                r#"{{"o":101,"c":"{} 안녕 나는 {} 이야"}}"#,
+                r#"{{"o":101, "r":"room_id", "c":"{} 안녕 나는 {} 이야"}}"#,
                 rand::random::<i64>(),
                 rand::random::<i64>()
             );

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,5 +1,7 @@
 //! websocket session
 
+use std::collections::BTreeSet;
+
 use axum::{extract::ws::Message, Error};
 use bson::oid::ObjectId;
 use tokio::sync::mpsc::UnboundedSender;
@@ -15,6 +17,7 @@ pub struct Session {
     id: String,
     tx: UnboundedSender<Result<Message, Error>>,
     user_info: Option<User>,
+    rooms: BTreeSet<String>,
 }
 
 impl Session {
@@ -23,6 +26,7 @@ impl Session {
             id: sid.into(),
             tx,
             user_info: None,
+            rooms: BTreeSet::new(),
         }
     }
 
@@ -34,6 +38,21 @@ impl Session {
     /// 유저정보 조회
     pub fn user(&self) -> Option<&User> {
         self.user_info.as_ref()
+    }
+
+    /// room에 조인
+    pub fn join(&mut self, room_id: &str) {
+        self.rooms.insert(room_id.to_owned());
+    }
+
+    /// room에 에서 제거
+    pub fn leave(&mut self, room_id: &str) {
+        self.rooms.remove(room_id);
+    }
+
+    /// room에 조인
+    pub fn is_joined(&self, room_id: &str) -> bool {
+        self.rooms.contains(room_id)
     }
 }
 

--- a/static/chat.html
+++ b/static/chat.html
@@ -45,7 +45,11 @@
     <p>AuthRequest</p>
     <p>{"o":10,"n":"user_name","i":"user_id"}</p>
     <p>SendTextRequest</p>
-    <p>{"o":101,"c":"안녕"}</p>
+    <p>{"o":101,"c":"안녕","r":"room_id"}</p>
+    <p>EnterRoomRequest</p>
+    <p>{"o":181,"r":"room_id"}</p>
+    <p>LeaveRoomRequest</p>
+    <p>{"o":191,"r":"room_id"}</p>
     <script type="text/javascript">
         const server = document.getElementById('server');
         const chat = document.getElementById('chat');


### PR DESCRIPTION
따로 채팅방을 생성하는 개념은 아니고 앱서버 내에서
채팅방을 기준으로 분리하는 개념임 레디스 채널을 분리 하지는 않음
레디스 채널 갯수는 많아질수록 성능이 급격히 떨어진다해서

근데 레디스 subscribe가 걱정되는게 한개 수신해서
리스트로 연결된 웹소켓 스트림들 순회해서 골라서 송신하는걸
생각했는데 레디스로부터 수신되는게 모든 각 웹소켓의 송신 스트림이
함수 코드가 실행돼 그러니까

500개 소캣이 한방에 연결 되어있으면 한명이 채팅 치면 1건의 수신이
레디스로부터 감지 되는게 아니라 500개의 수신이 감지되고 해당
함수는 이미 그 해당 웹소켓 세션의 영역으로 한정되어있음 앱서버에서
미리 필터링 할 필요가 없다는거임 이게 성능상 더 안좋을꺼 같은디

Close #7 