### PR TITLE
Single redis subscribe

### DIFF
--- a/examples/redis_client.rs
+++ b/examples/redis_client.rs
@@ -1,0 +1,116 @@
+//! redis client program
+//!
+//! redis publish only 무조건 송신함
+//! `RUST_LOG=info cargo run --example ws_client`
+
+use chrono::Utc;
+use fred::{
+    prelude::{ClientLike, PubsubInterface, RedisClient},
+    types::{ReconnectPolicy, RedisConfig},
+};
+use log::{debug, info};
+use rand::{distributions::Uniform, prelude::Distribution};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tokio::time::{self, Instant};
+
+#[derive(Debug)]
+pub struct Status(pub i64, pub i64, pub u32);
+
+const CLIENT_COUNT: u64 = 2600;
+const CLIENT_CREATING_PERIOD: u64 = 30;
+const CHAT_CREATING_PERIOD: u64 = 333;
+
+#[tokio::main]
+async fn main() {
+    // RUST_LOG 가 없으면 기본 레벨 지정
+    env_logger::builder()
+        .parse_filters(&std::env::var("RUST_LOG").unwrap_or_else(|_| "debug".into()))
+        .format_timestamp_millis()
+        .init();
+
+    // 스레드간 공유되는 상태로 수신 메시지 갯수 송신 메시지 갯수
+    let status: Arc<Mutex<Status>> = Arc::new(Mutex::new(Status(0, 0, 0)));
+    let mut handles = vec![];
+    let cloned_status = status.clone();
+
+    let config = RedisConfig::default();
+    let policy = ReconnectPolicy::default();
+    let redis_client = RedisClient::new(config.clone());
+    let _ = redis_client.connect(Some(policy.clone()));
+    let _ = redis_client.wait_for_connect().await.unwrap();
+
+    let show_status = tokio::spawn(async move {
+        let mut interval = time::interval(Duration::from_secs(1));
+        loop {
+            interval.tick().await;
+            info!("status: {:?}", cloned_status.lock().unwrap(),);
+        }
+    });
+    handles.push(show_status);
+
+    let mut rng = rand::thread_rng();
+    let random_number: Uniform<i32> = Uniform::from(1..1000);
+    for c in 0..CLIENT_COUNT {
+        let enable_send = if c < 100 && random_number.sample(&mut rng) <= 100 {
+            // 클라 100개 미만일시 10프로 확률로 전송 기능 활성화
+            true
+        } else {
+            // 100개 이상이면 1프로로 확률 변경
+            c >= 100 && random_number.sample(&mut rng) <= 10
+        };
+        let redis_client = redis_client.clone();
+        // 0.1 초씩 클라이언트 증가
+        time::sleep(Duration::from_millis(CLIENT_CREATING_PERIOD)).await;
+        let cloned_status = status.clone();
+        let h = tokio::spawn(async move {
+            run_test(cloned_status.clone(), enable_send, redis_client).await;
+        });
+        handles.push(h);
+    }
+
+    for h in handles {
+        h.await.unwrap();
+    }
+    // let a = futures::future::join_all(handles);
+}
+
+pub async fn run_test(status: Arc<Mutex<Status>>, _enable_send: bool, redis_client: RedisClient) {
+    // info!("enable_send: {}", enable_send);
+    // tasks 수 더하기
+    let cloned_status = status.clone();
+    cloned_status.lock().unwrap().2 += 1;
+    drop(cloned_status);
+
+    debug!("수신 시작");
+
+    // 0.3초 마다 랜덤 숫자 넣은 채팅 전송
+    let cloned_status = status.clone();
+    let stop_watch = Instant::now();
+    let send_task = tokio::spawn(async move {
+        let mut interval = time::interval(Duration::from_millis(CHAT_CREATING_PERIOD));
+        loop {
+            interval.tick().await;
+            let now = Utc::now().naive_utc().timestamp_millis();
+            let millisecond_part = now % 1000;
+            // info!("millisecond_part: {}", millisecond_part);
+            // 현재 밀리세컨드가 300초 이하면 송신 한다 송실한 클라도 랜덤이지만 매 시간마다
+            // 송신 하는 행위도 랜덤으로 하도록 지정
+            if millisecond_part < 999 && stop_watch.elapsed().as_millis() > 2000 {
+                // 2초 이내면 실행 안함 최초 실행을 막고 지정된 interval 대로 메시지 송신 하기 위함
+                let msg = format!(
+                    r#"{{"o":101, "r":"room_id", "c":"{} 안녕 나는 {} 이야"}}"#,
+                    rand::random::<i64>(),
+                    rand::random::<i64>()
+                );
+                // info!("보내기전");
+                let _received_clients: i64 = redis_client.publish("zxc", &msg).await.unwrap();
+                // info!("보냄 {}", received_clients);
+                cloned_status.lock().unwrap().1 += 1;
+            }
+        }
+    });
+    send_task.await.unwrap();
+}

--- a/examples/ws_client.rs
+++ b/examples/ws_client.rs
@@ -20,8 +20,8 @@ const WS_ENDPOINT: &str = "ws://localhost:3000/websocket";
 pub struct Status(pub i64, pub i64, pub u32);
 
 const CLIENT_COUNT: u64 = 99999;
-const CLIENT_CREATING_PERIOD: u64 = 33;
-const CHAT_CREATING_PERIOD: u64 = 133;
+const CLIENT_CREATING_PERIOD: u64 = 30;
+const CHAT_CREATING_PERIOD: u64 = 1333;
 
 #[tokio::main]
 async fn main() {

--- a/src/session.rs
+++ b/src/session.rs
@@ -17,7 +17,6 @@ pub struct Session {
     id: String,
     tx: UnboundedSender<Result<Message, Error>>,
     user_info: Option<User>,
-    rooms: BTreeSet<String>,
 }
 
 impl Session {
@@ -26,7 +25,6 @@ impl Session {
             id: sid.into(),
             tx,
             user_info: None,
-            rooms: BTreeSet::new(),
         }
     }
 
@@ -40,19 +38,9 @@ impl Session {
         self.user_info.as_ref()
     }
 
-    /// room에 조인
-    pub fn join(&mut self, room_id: &str) {
-        self.rooms.insert(room_id.to_owned());
-    }
-
-    /// room에 에서 제거
-    pub fn leave(&mut self, room_id: &str) {
-        self.rooms.remove(room_id);
-    }
-
-    /// room에 조인
-    pub fn is_joined(&self, room_id: &str) -> bool {
-        self.rooms.contains(room_id)
+    /// 해당 세션으로 데이터 송신
+    pub fn send(&self, msg: String) {
+        let _ = self.tx.send(Ok(Message::Text(msg)));
     }
 }
 

--- a/static/chat.html
+++ b/static/chat.html
@@ -61,6 +61,10 @@
             const line = document.createElement('p');
             line.innerText = data;
             chat.appendChild(line);
+            if (chat.childElementCount > 10) {
+                // 10개 이상 채팅 내역이 쌓이면 처음꺼 제거 한다
+                chat.removeChild(chat.children[0])
+            }
         }
 
         send.onclick = function () {


### PR DESCRIPTION
1. tokio broadcast channle
2. session 별 redis subscribe
3. seesion scope 밖에 단일 redis subscribe

기존 방식은 2번인데 3번으로 옮긴것임 수천 클라이언트가 수천개 한번에 송신하면 서버가 응답없어지는 stuck 상태가 되긴 하지만 #17 마지막을 보다시지 2번 보다 3번이 확실히 더 효율적인건 맞음